### PR TITLE
Timeline: minute calculation fix

### DIFF
--- a/src/plugins/timeline.ts
+++ b/src/plugins/timeline.ts
@@ -86,7 +86,7 @@ class TimelinePlugin extends BasePlugin<TimelinePluginEvents, TimelinePluginOpti
   private formatTime(seconds: number): string {
     if (seconds / 60 > 1) {
       // calculate minutes and seconds from seconds count
-      const minutes = Math.round(seconds / 60)
+      const minutes = Math.floor(seconds / 60)
       seconds = Math.round(seconds % 60)
       const paddedSeconds = `${seconds < 10 ? '0' : ''}${seconds}`
       return `${minutes}:${paddedSeconds}`


### PR DESCRIPTION
I noticed a small bug in the timeline labels:

![Screen Shot 2023-05-08 at 6 15 16 PM](https://user-images.githubusercontent.com/12655228/236969515-7fac8ad5-75e9-40a6-9709-42e2b4b4c029.png)
